### PR TITLE
add updaters for updating super-fields of sub-structs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 compiled/
+doc/
+*~

--- a/struct-update-doc/scribblings/struct-update.scrbl
+++ b/struct-update-doc/scribblings/struct-update.scrbl
@@ -51,6 +51,22 @@ lexical context of @racket[struct-id]. Each setter function is protected by the 
   (define-struct-updaters point)
   (point-x-set (point 1 2) 10)
   (point-y-update (point 1 2) add1))
+
+If @racket[struct-id] is a substruct of @racketvarfont{super-id}, then it generates setters and
+updaters for the super fields as well. These are generated as
+@elem{@racket[struct-id]@racketidfont{-}@racketvarfont{super-id}@racketidfont{-}@racket[field-id]@racket[-set]} and
+@elem{@racket[struct-id]@racketidfont{-}@racketvarfont{super-id}@racketidfont{-}@racket[field-id]@racket[-update]}
+so that they can return instances of @racket[struct-id] instead of @racketvarfont{super-id}.
+
+@(struct-update-eval
+  (struct object (mass position) #:transparent)
+  (struct movable object (velocity) #:transparent)
+  (define-struct-updaters object)
+  (define-struct-updaters movable)
+  (object-mass-set (object 5 (list 1 2)) 10)
+  (object-mass-set (movable 5 (list 1 2) (list 0 0)) 10)
+  (movable-velocity-set (movable 5 (list 1 2) (list 0 0)) (list -3 -4))
+  (movable-object-mass-set (movable 5 (list 1 2) (list 0 0)) 10))
 }}}
 
 @defform[(struct-updaters-out struct-id)]{

--- a/struct-update-lib/struct-update/main.rkt
+++ b/struct-update-lib/struct-update/main.rkt
@@ -34,12 +34,18 @@
       ; perform the functional update
       #:attr constructor-id (@ struct.constructor-id)
       #:with ([set-id update-id accessor-id [pre-accessor-id ...] [post-accessor-id ...]] ...)
-             (for/list ([(accessor-id index) (in-indexed (in-list (@ struct.own-accessor-id)))])
-              (let-values ([[pre current+post] (split-at (@ struct.accessor-id)
-                                                         (+ (@ struct.num-supertype-fields) index))])
-                (list (format-id #'struct "~a-set" accessor-id #:source #'struct #:props #'struct)
-                      (format-id #'struct "~a-update" accessor-id #:source #'struct #:props #'struct)
-                      accessor-id pre (rest current+post))))]))
+             (for/list ([(accessor-id index) (in-indexed (in-list (@ struct.accessor-id)))])
+                (let-values ([[pre current+post] (split-at (@ struct.accessor-id)
+                                                           index)])
+                  (cond
+                    [(< index (@ struct.num-supertype-fields))
+                     (list (format-id #'struct "~a-~a-set" #'struct accessor-id #:source #'struct #:props #'struct)
+                           (format-id #'struct "~a-~a-update" #'struct accessor-id #:source #'struct #:props #'struct)
+                           accessor-id pre (rest current+post))]
+                    [else
+                     (list (format-id #'struct "~a-set" accessor-id #:source #'struct #:props #'struct)
+                           (format-id #'struct "~a-update" accessor-id #:source #'struct #:props #'struct)
+                           accessor-id pre (rest current+post))])))]))
 
 (define-syntax (define-struct-updaters stx)
   (with-disappeared-uses

--- a/struct-update-test/tests/struct-update-super.rkt
+++ b/struct-update-test/tests/struct-update-super.rkt
@@ -1,0 +1,45 @@
+#lang racket/base
+
+(require struct-update
+         rackunit
+         rackunit/spec)
+
+(struct super (a b c) #:transparent)
+(struct sub super (c a t) #:transparent)
+(struct subsub sub (b a) #:transparent)
+
+(define-struct-updaters super)
+(define-struct-updaters sub)
+(define-struct-updaters subsub)
+
+(describe "define-struct-updaters"
+  ;; Updaters for non-super-parts of instances of structs
+  (it "generates functional setter and updater functions"
+    (check-equal? (super-a-set (super 0 1 2) 5) (super 5 1 2))
+    (check-equal? (super-b-update (super 3 1 4) add1) (super 3 2 4)))
+  (it "generates setter and updater functions for the sub struct"
+    (check-equal? (sub-a-set (sub 0 1 2 3 4 5) 6) (sub 0 1 2 3 6 5))
+    (check-equal? (sub-c-update (sub 3 1 4 1 5 9) add1) (sub 3 1 4 2 5 9)))
+  (it "generates setters and updaters for the subsub struct"
+    (check-equal? (subsub-a-set (subsub 0 1 2 3 4 5 6 7) 8)
+                  (subsub 0 1 2 3 4 5 6 8))
+    (check-equal? (subsub-b-update (subsub 3 1 4 1 5 9 2 7) add1)
+                  (subsub 3 1 4 1 5 9 3 7)))
+  
+  ;; Updaters for super-parts of instances of sub-structs
+  (it "generates setters and updaters for super-fields within the sub struct"
+    (check-equal? (sub-super-a-set (sub 0 1 2 3 4 5) 6)
+                  (sub 6 1 2 3 4 5))
+    (check-equal? (sub-super-c-update (sub 1 2 4 8 7 6) add1)
+                  (sub 1 2 5 8 7 6)))
+  (it "generates setters and updaters for sub-fields within the subsub struct"
+    (check-equal? (subsub-sub-c-set (subsub 0 1 2 3 4 5 6 7) 8)
+                  (subsub 0 1 2 8 4 5 6 7))
+    (check-equal? (subsub-sub-a-update (subsub 3 1 4 1 5 9 2 7) add1)
+                  (subsub 3 1 4 1 6 9 2 7)))
+  (it "generates setters and updaters for super-fields within the subsub struct"
+    (check-equal? (subsub-super-c-set (subsub 0 1 2 3 4 5 6 7) 8)
+                  (subsub 0 1 8 3 4 5 6 7))
+    (check-equal? (subsub-super-a-update (subsub 3 1 4 1 5 9 2 7) add1)
+                  (subsub 4 1 4 1 5 9 2 7)))
+  )


### PR DESCRIPTION
For structs like
```racket
(struct foo (a b c))
(struct sub foo (c a t))
```
Using `(define-struct-updaters sub)` defines `-set` and `-update` functions for `sub-c`, `sub-a`, `sub-t`, but it also defines them for `sub-foo-a`, `sub-foo-b`, and `sub-foo-c`. These new ones modify the `foo` part of a `sub` instance, but they preserve the `sub` information.

Closes https://github.com/lexi-lambda/struct-update/issues/1